### PR TITLE
Allow setting the hostname & key as parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ $ go-datarobot \
     -user example@example.com \
     -token <your api token> \
     -project <project id> \
-    -model <model id>
+    -model <model id> \
+    -host <dedicated host> \
+    -key <dedicated host key>
 
 ======== running setting ==========
 input: ./example/input.csv
@@ -69,7 +71,9 @@ user_id,flag,true,false
 - `-token`: datarobot account api token (required)
 - `-project`: datarobot account project id (required)
 - `-model`: datarobot account model id (required)
-- `-block`: row data size to send api request (default:1000)
+- `-block`: row data size to send api request (default: 1000)
+- `-host` : dedicated hostname; will use shared host if none given (default: https://app.datarobot.com)
+- `-key` : dedicated host key (default: )
 
 ## API client
 

--- a/apiclient/config/config.go
+++ b/apiclient/config/config.go
@@ -14,17 +14,15 @@ type Config struct {
 }
 
 // NewWithToken returns initialized Config with api token
-func NewWithToken(user, token, hostName, key string) Config {
-	h := hostName
-	k := key
-	if h == "" {
-		h = endpointApp
-	}
-
+func NewWithTokenAndHost(user, token, hostName, key string) Config {
 	return Config{
-		HostName: h,
-		Key: k,
+		HostName: hostName,
+		Key: key,
 		User:  user,
 		Token: token,
 	}
+}
+
+func NewWithToken(user, token string) Config {
+	return NewWithTokenAndHost(user, token, endpointApp, "")
 }

--- a/apiclient/config/config.go
+++ b/apiclient/config/config.go
@@ -1,15 +1,29 @@
 package config
 
+const (
+       endpointApp = "https://app.datarobot.com"
+)
+
 // Config has auth data for datarobot api
 type Config struct {
+	HostName string
+        Key      string
 	User     string
 	Token    string
 	Password string
 }
 
 // NewWithToken returns initialized Config with api token
-func NewWithToken(user, token string) Config {
+func NewWithToken(user, token, hostName, key string) Config {
+	       h := hostName
+	       k := key
+	       if h == "" {
+		       h = endpointApp
+	       }
+
 	return Config{
+		HostName: h,
+		Key: k,
 		User:  user,
 		Token: token,
 	}

--- a/apiclient/config/config.go
+++ b/apiclient/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 const (
-       endpointApp = "https://app.datarobot.com"
+	endpointApp = "https://app.datarobot.com"
 )
 
 // Config has auth data for datarobot api
 type Config struct {
 	HostName string
-        Key      string
+	Key      string
 	User     string
 	Token    string
 	Password string
@@ -15,11 +15,11 @@ type Config struct {
 
 // NewWithToken returns initialized Config with api token
 func NewWithToken(user, token, hostName, key string) Config {
-	       h := hostName
-	       k := key
-	       if h == "" {
-		       h = endpointApp
-	       }
+	h := hostName
+	k := key
+	if h == "" {
+		h = endpointApp
+	}
 
 	return Config{
 		HostName: h,

--- a/apiclient/request/request.go
+++ b/apiclient/request/request.go
@@ -7,21 +7,19 @@ import (
 
 	"github.com/evalphobia/go-datarobot/apiclient/config"
 )
-
-const (
-	endpointApp = "https://app.datarobot.com"
-)
-
 // Post sends POST request to datarobot api
 func Post(c config.Config, path string, param interface{}) (*Response, error) {
 	cli := gentleman.New()
 	cli.Use(auth.Basic(c.User, c.Token))
-	cli.URL(endpointApp)
+	cli.URL(c.HostName)
 
 	req := cli.Request()
 	req.Path(path)
 	req.Use(body.JSON(param))
 	req.Method("POST")
+	if c.Key != "" {
+		req.AddHeader("datarobot-key", c.Key)
+	}
 
 	res, err := req.Send()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ var (
 	token     string
 	projectID string
 	modelID   string
+	hostName  string
+	key       string
 	blockSize int
 
 	lock = sync.Mutex{}
@@ -29,14 +31,17 @@ func initFlag() {
 	flag.StringVar(&token, "token", "", "datarobot api token")
 	flag.StringVar(&projectID, "project", "", "datarobot project_id")
 	flag.StringVar(&modelID, "model", "", "datarobot model_id")
+	flag.StringVar(&hostName, "host", "", "datarobot dedicated host")
+	flag.StringVar(&key, "key", "", "datarbot dedicated host key")
 	flag.IntVar(&blockSize, "block", 1000, "block data size to send api request")
 	flag.Parse()
 
 	fmt.Println("======== running setting ==========")
-	fmt.Printf("input: %s\noutput: %s\nuser: %s\nproject: %s\nmodel: %s\nblock size: %d\n",
+	fmt.Printf("input: %s\noutput: %s\nuser: %s\nproject: %s\nmodel: %s\nblock size: %d\nhost name: %s\nkey: %s\n",
 		input, output,
 		user, projectID, modelID,
-		blockSize)
+		blockSize, hostName,
+		key)
 	fmt.Println("====================================")
 }
 
@@ -54,7 +59,7 @@ func main() {
 	readCh := readLines(csv)
 
 	// send req
-	c := config.NewWithToken(user, token)
+	c := config.NewWithToken(user, token, hostName, key)
 	maxReq := make(chan bool, 5)
 	writeCh := make(chan apiResult)
 	reqCount := 0

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	readCh := readLines(csv)
 
 	// send req
-	c := config.NewWithToken(user, token, hostName, key)
+	c := config.NewWithTokenAndHost(user, token, hostName, key)
 	maxReq := make(chan bool, 5)
 	writeCh := make(chan apiResult)
 	reqCount := 0

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func initFlag() {
 	flag.StringVar(&token, "token", "", "datarobot api token")
 	flag.StringVar(&projectID, "project", "", "datarobot project_id")
 	flag.StringVar(&modelID, "model", "", "datarobot model_id")
-	flag.StringVar(&hostName, "host", "", "datarobot dedicated host")
+	flag.StringVar(&hostName, "host", "https://app.datarobot.com", "datarobot dedicated host")
 	flag.StringVar(&key, "key", "", "datarbot dedicated host key")
 	flag.IntVar(&blockSize, "block", 1000, "block data size to send api request")
 	flag.Parse()


### PR DESCRIPTION
Allow the user to set the hostname and key as parameters for dedicated instance users.
(Maintains the same functionality as before when no hostname & key are set)